### PR TITLE
Add Gradle configuration to deploy to Maven repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 build
 
 .idea
+/.settings
+/.classpath
+/.project

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,11 @@ dependencies {
 group = "com.github.dnault"
 version = "0.1.0-SNAPSHOT"
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 publishing {
     publications {
         maven(MavenPublication) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
 
 plugins {
     id 'java-library'
+    id 'maven-publish'
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
 }
 
@@ -14,6 +16,18 @@ dependencies {
 
 group = "com.github.dnault"
 version = "0.1.0-SNAPSHOT"
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.github.dnault'
+            artifactId = 'libresample4j'
+            version = '0.1.0-SNAPSHOT'
+
+            from components.java
+        }
+    }
+}
 
 targetCompatibility = '1.7'
 sourceCompatibility = '1.7'


### PR DESCRIPTION
To use the library from other projects, it is best to have a Maven dependency to import. The added configuration allows to add the library at least to the local machine's Maven repository. Even better would be if a version of the library could be deployed to Maven-Central.